### PR TITLE
Add support for generating module documentation via `PlatyPS`

### DIFF
--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -2,7 +2,7 @@
 $zerofailedExtensions = @(
     @{
         Name = "ZeroFailed.Build.PowerShell"
-        # It uses itself as a dependency, so we can use the current path
+        # It uses itself as a dependency, so we test the local repository version
         Path = "$here\module"
     }
 )

--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -13,6 +13,17 @@ $zerofailedExtensions = @(
 # Set the required build options
 $PesterTestsDir = "$here/module"
 $PesterCodeCoveragePaths = @("$here/module/functions")
+$PowerShellModulesToPublish = @(
+    @{
+        ModulePath = "$here/module/ZeroFailed.Build.PowerShell.psd1"
+        FunctionsToExport = @("*")
+        CmdletsToExport = @()
+        AliasesToExport = @()
+    }
+)
+$PSMarkdownDocsFlattenOutputPath = $true
+$PSMarkdownDocsOutputPath = './docs/functions'
+$PSMarkdownDocsIncludeModulePage = $false
 
 # Customise the build process
 task . FullBuild

--- a/HELP.md
+++ b/HELP.md
@@ -2,6 +2,21 @@
 
 <!-- START_GENERATED_HELP -->
 
+## Documentation
+
+This group contains functionality for maintaining PowerShell module documentation.
+
+### Properties
+
+| Name                              | Default Value | ENV Override                              | Description                                                                                                                                     |
+| --------------------------------- | ------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SkipGeneratePSMarkdownDocs`      | $false        |                                           | When true, all markdown documentation will tasks will be skipped.                                                                               |
+| `PSMarkdownDocsOutputPath`        | './docs'      | `ZF_BUILD_PS_MD_DOCS_OUTPUT_PATH`         | The base output path for generated markdown files.                                                                                              |
+| `PSMarkdownDocsFlattenOutputPath` | $false        | `ZF_BUILD_PS_MD_DOCS_FLATTEN_OUTPUT_PATH` | When true, works around default PlatyPS behaviour of placing markdown files in a sub-folder named after the module.                             |
+| `PSMarkdownDocsIncludeModulePage` | $true         |                                           | When true, PlatyPS will generate a markdown index page for the module.                                                                          |
+| `PSMarkdownDocsRequireLinting`    | $true         |                                           | When true, failed markdown linting (e.g. to ensure no generated placeholder text) will break the build, otherwise they are treated as warnings. |
+
+
 ## Publish
 
 This group contains functionality for publishing PowerShell modules to repositories.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ kanban
     init
     version
     build
+        ensurePlatyPSModule[Install PlatyPS]
+        genMarkdownDocs[Generate Module Markdown Docs]
+        runMarkdownLinting[Run Markdown Docs Linting]
     test
         installPester[Install Pester]
         runPester[Run Pester]

--- a/module/tasks/documentation.properties.ps1
+++ b/module/tasks/documentation.properties.ps1
@@ -8,8 +8,11 @@ $SkipGeneratePSMarkdownDocs = $false
 # Synopsis: The base output path for generated markdown files.
 $PSMarkdownDocsOutputPath = property ZF_BUILD_PS_MD_DOCS_OUTPUT_PATH './docs'
 
-# Synopsis: When true, overrides PlatyPS behaviour of placing markdown files in a sub-folder named after the module.
+# Synopsis: When true, works around default PlatyPS behaviour of placing markdown files in a sub-folder named after the module.
 $PSMarkdownDocsFlattenOutputPath = [Convert]::ToBoolean((property ZF_BUILD_PS_MD_DOCS_FLATTEN_OUTPUT_PATH $false))
 
 # Synopsis: When true, PlatyPS will generate a markdown index page for the module.
 $PSMarkdownDocsIncludeModulePage = $true
+
+# Synopsis: When true, failed markdown linting (e.g. to ensure no generated placeholder text) will break the build, otherwise treated as a warning.
+$PSMarkdownDocsRequireLinting = $true

--- a/module/tasks/documentation.properties.ps1
+++ b/module/tasks/documentation.properties.ps1
@@ -1,0 +1,15 @@
+# <copyright file="documentation.properties.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+# Synopsis: When true, all markdown documentation will tasks will be skipped.
+$SkipGeneratePSMarkdownDocs = $false
+
+# Synopsis: The base output path for generated markdown files.
+$PSMarkdownDocsOutputPath = property ZF_BUILD_PS_MD_DOCS_OUTPUT_PATH './docs'
+
+# Synopsis: When true, overrides PlatyPS behaviour of placing markdown files in a sub-folder named after the module.
+$PSMarkdownDocsFlattenOutputPath = [Convert]::ToBoolean((property ZF_BUILD_PS_MD_DOCS_FLATTEN_OUTPUT_PATH $false))
+
+# Synopsis: When true, PlatyPS will generate a markdown index page for the module.
+$PSMarkdownDocsIncludeModulePage = $true

--- a/module/tasks/documentation.tasks.ps1
+++ b/module/tasks/documentation.tasks.ps1
@@ -122,7 +122,7 @@ task RunPSMarkdownDocsLinting `
 
     $noPlaceholderText = $true
     Measure-PlatyPSMarkdown -Path $PSMarkdownDocsOutputPath\*.md |
-        Where-Object { $_.MarkdownContent.MarkdownLines -inotmatch '\"\{\{.*\}\}\"' } |
+        Where-Object { $_.MarkdownContent.MarkdownLines -imatch '\"\{\{.*\}\}\"' } |
         ForEach-Object {
             Write-Build Red "[PlaceholdersDetected] File '$($_.FilePath.Replace("$here\",''))' contains generated documentation placeholders"
             $noPlaceholderText = $false

--- a/module/tasks/documentation.tasks.ps1
+++ b/module/tasks/documentation.tasks.ps1
@@ -1,0 +1,103 @@
+# <copyright file="documentation.tasks.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+. $PSScriptRoot/documentation.properties.ps1
+
+# Synopsis: Ensures the required PlatyPS module is available
+task EnsurePlatyPSModule -Before setupModules {
+
+    if (!$RequiredPowerShellModules.ContainsKey('Microsoft.PowerShell.PlatyPS')) {
+        $script:RequiredPowerShellModules += @{
+            'Microsoft.PowerShell.PlatyPS' = @{
+                version = '[1.0,2.0)'
+                repository = 'PSGallery'
+            }
+        }
+    }
+}
+
+# This scriptblock is used as a compensation task to ensure that if we are using
+# the 'flattened' output path option for Markdown files, then our special handling in
+# 'MoveMarkdownFilesForPlatyPS' gets reverted even if an error happens during
+# processing.
+$_moveMarkdownFilesToOutputPath = {
+    foreach ($module in $PowerShellModulesToPublish) {
+
+        $moduleName = Split-Path -LeafBase $module.ModulePath
+        $outputPathExpectedByPlatyPS = Join-Path $PSMarkdownDocsOutputPath $moduleName
+
+        # Handle the scenario where we had an error before anything actually got moved
+        if (Test-Path $outputPathExpectedByPlatyPS) {
+            # Move the markdown files back to where we want them
+            Move-Item -Path $outputPathExpectedByPlatyPS\*.md -Destination $PSMarkdownDocsOutputPath\
+            Remove-Item $outputPathExpectedByPlatyPS
+        }
+    }
+}
+
+# Synopsis: Ensures existing markdown files in the place that PlatyPS expects them when using a custom output path
+task MoveMarkdownFilesForPlatyPS -If { $PSMarkdownDocsFlattenOutputPath } {
+
+    # Setup compensation task to ensure that these files get moved back if an error happens that
+    # would otherwise prevent the later 'MoveMarkdownFilesToOutputPath' task from running.
+    $script:OnExitActions.Add($_moveMarkdownFilesToOutputPath)
+
+    # PlatyPS expects to find existing markdown files in a folder named after the module, but
+    # this is not always desirable when a repo only contains a single module.  We need to temporarily
+    # move the files around to keep PlatyPS happy.
+    foreach ($module in $PowerShellModulesToPublish) {
+
+        $moduleName = Split-Path -LeafBase $module.ModulePath
+        $outputPathExpectedByPlatyPS = Join-Path $PSMarkdownDocsOutputPath $moduleName
+    
+        # Put .md files where the New-MarkdownCommandHelp cmdlet expects to find them
+        New-Item $outputPathExpectedByPlatyPS -ItemType Directory -Force | Out-Null
+        Move-Item -Path $PSMarkdownDocsOutputPath\*.md -Destination $outputPathExpectedByPlatyPS\
+    }
+}
+
+# Synopsis: Uses PlatyPS to generate/update existing markdown documentation
+task GeneratePowerShellMarkdownDocumentation `
+    -If { !$SkipGenerateMarkdownDocumentation } `
+    -After BuildCore `
+    -Jobs GitVersion,EnsurePlatyPSModule,MoveMarkdownFilesForPlatyPS,{
+
+    foreach ($module in $PowerShellModulesToPublish) {
+
+        $moduleName = Split-Path -LeafBase $module.ModulePath
+        Write-Build White "Generating/updating markdown help documentation: $moduleName"
+
+        # Ensure latest version of module is imported
+        Import-Module $module.ModulePath -Force
+    
+        # Generate any markdown files for new functions
+        $newMarkdownCommandHelpSplat = @{
+            ModuleInfo = Get-Module $moduleName
+            OutputFolder = $PSMarkdownDocsOutputPath
+            HelpVersion = $Gitversion.AssemblySemVer
+            WithModulePage = $PSMarkdownDocsIncludeModulePage 
+            WarningAction = 'SilentlyContinue'  # suppress warnings about pre-existing files
+        }
+        $newFiles = New-MarkdownCommandHelp @newMarkdownCommandHelpSplat
+
+        if ($newFiles) {
+            Write-Build White "New files:`n`t$($newFiles.Name -join "`n`t")"
+        }
+    
+        # Derive path where the existing markdown files actually reside
+        $existingMarkdownFilePath = Join-Path $PSMarkdownDocsOutputPath $moduleName
+
+        if (Test-Path $existingMarkdownFilePath) {
+            # Update existing markdown files to reflect changes in latest version
+            $updatedFiles = Measure-PlatyPSMarkdown -Path $existingMarkdownFilePath\*.md |
+                                Where-Object Filetype -match 'CommandHelp' |
+                                Update-CommandHelp -Path {$_.FilePath} |
+                                Export-MarkdownCommandHelp -OutputFolder $PSMarkdownDocsOutputPath -Force
+            
+            if ($updatedFiles) {
+                Write-Build White "Updated files:`n`t$($updatedFiles.Name -join "`n`t")"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds new tasks and properties for generating markdown documentation using [PlatyPS](https://github.com/PowerShell/platyPS) v1.x and performing some initial linting of the generated files (e.g. ensure no generated placeholder text).

This means that modules should no longer use documentation comments defined alongside the functions when authoring help content.  Instead, this new functionality will generate template markdown files for each function the module exports which must be maintained as first-class repo artefacts (i.e. they become the source of the truth regarding documentation).

Once created, PlatyPS will take take care of updating them when chaanges are made to functions as part of the build process.